### PR TITLE
Change README.md links to be accurate

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 This is the repository for my bookings and reservations project.
 
 - Build in Go version 1.19
-- Uses the [chi router](https://github.com/alexedwards/scs/v2)
-- Uses [alex edwards SCS session management](https://github.com/go-chi/chi/v5)
+- Uses the [chi router](https://github.com/go-chi/chi)
+- Uses [alex edwards SCS session management](https://github.com/alexedwards/scs)
 - Uses [nosurf](https://github.com/justinas/nosurf)


### PR DESCRIPTION
This pull request changes the links in the file `README.md` to go to the places referenced in the text of those links. It's a pretty straightforward and simple fix.